### PR TITLE
Fix residual prediction integration and evaluation access

### DIFF
--- a/run_experiments.py
+++ b/run_experiments.py
@@ -40,6 +40,12 @@ def main():
     args = parser.parse_args()
     
     if args.evaluate_only:
+        # show all columns/rows
+        import pandas as pd
+        pd.set_option('display.max_rows', None)
+        pd.set_option('display.max_columns', None)
+        pd.set_option('display.width', 144)
+
         # Just evaluate existing results
         tracker = ExperimentTracker(args.experiment)
         eval_results = tracker.evaluate_models(min_stellar_mass=args.min_stellar_mass, only_centrals=args.only_centrals)

--- a/src/experiment_tracker.py
+++ b/src/experiment_tracker.py
@@ -518,9 +518,8 @@ class ExperimentTracker:
         if metrics is None:
             metrics = ['rmse', 'mae', 'nmad', 'r2', 'pearson']
         
-        # Find all prediction files (exclude residual files)
-        pred_files = [f for f in self.predictions_dir.glob('*_predictions.csv') 
-                      if 'residual' not in f.name]
+        # Find all prediction files (include residual files)
+        pred_files = list(self.predictions_dir.glob('*_predictions.csv'))
         
         print(f"Evaluating {len(pred_files)} prediction files")
         

--- a/src/train.py
+++ b/src/train.py
@@ -284,9 +284,13 @@ def train_merger_gnn_tracked(experiment_name: str, fold: int = None,
         
         optimizer = configure_optimizer(model, config['lr'], config['weight_decay'])
         
+        # Determine model name for logging (before training loop)
+        model_name = f'merger_gnn_residual_{base_model}' if residual_mode else 'merger_gnn'
+        
         # Set up logging
-        log_file = tracker.logs_dir / f"merger_gnn_fold_{k}.log"
-        logger = TrainingLogger(log_file, f"Merger Tree GNN Fold {k}")
+        log_file = tracker.logs_dir / f"{model_name}_fold_{k}.log"
+        logger_title = f"Merger Tree GNN (Residual {base_model}) Fold {k}" if residual_mode else f"Merger Tree GNN Fold {k}"
+        logger = TrainingLogger(log_file, logger_title)
         logger.write_header()
         
         # Training loop
@@ -325,8 +329,7 @@ def train_merger_gnn_tracked(experiment_name: str, fold: int = None,
             'best_valid_loss': best_loss
         }
         
-        # Determine model name based on residual mode
-        model_name = f'merger_gnn_residual_{base_model}' if residual_mode else 'merger_gnn'
+        # Model name was already determined above for logging
         
         tracker.record_model_training(model_name, k, config, final_metrics, model)
         


### PR DESCRIPTION
- Fix evaluation filter to include residual predictions in evaluate_models()
- Fix log file naming for residual models to use full model name
- Ensure residual models use consistent {model}_residual_{base} naming
- Enable --evaluate-only flag to correctly process residual predictions
- Add pandas display options for better evaluation output formatting

This resolves issues where residual model predictions were excluded from evaluation and log files were being overwritten between regular and residual model training runs.